### PR TITLE
Use enum value explicitly for python 3.11 compatability (Fixes #16)

### DIFF
--- a/arcee/api.py
+++ b/arcee/api.py
@@ -20,7 +20,7 @@ def upload_doc(
     """
     doc = {"name": doc_name, "document": doc_text, "meta": kwargs}
     data = {"context_name": context, "documents": [doc]}
-    return make_request("post", Route.contexts, data)
+    return make_request("post", Route.contexts.value, data)
 
 
 def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:
@@ -46,14 +46,14 @@ def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:
         doc_list.append(new_doc)
 
     data = {"context_name": context, "documents": doc_list}
-    return make_request("post", Route.contexts, data)
+    return make_request("post", Route.contexts.value, data)
 
 
 def train_dalm(
     name: str, context: Optional[str] = None, instructions: Optional[str] = None, generator: str = "Command"
 ) -> None:
     data = {"name": name, "context": context, "instructions": instructions, "generator": generator}
-    make_request("post", Route.train_model, data)
+    make_request("post", Route.train_model.value, data)
     org = get_current_org()
     status_url = f"{config.ARCEE_APP_URL}/{org}/models/{name}/training"
     print(
@@ -68,7 +68,7 @@ def get_dalm_status(id_or_name: str) -> Dict[str, str]:
 
 
 def get_current_org() -> str:
-    return make_request("get", Route.identity)["org"]
+    return make_request("get", Route.identity.value)["org"]
 
 
 def get_dalm(name: str) -> DALM:

--- a/arcee/dalm.py
+++ b/arcee/dalm.py
@@ -60,7 +60,7 @@ class DALM:
     def invoke(
         self, invocation_type: Literal["retrieve", "generate"], query: str, size: int, filters: List[Dict]
     ) -> Dict[str, Any]:
-        route = Route.retrieve if invocation_type == "retrieve" else Route.generate
+        route = Route.retrieve.value if invocation_type == "retrieve" else Route.generate.value
         payload = {"model_id": self.model_id, "query": query, "size": size, "filters": filters, "id": self.model_id}
         return make_request("post", route, body=payload)
 

--- a/tasks.py
+++ b/tasks.py
@@ -189,9 +189,9 @@ def _bump_version(version: str, bump: Optional[BumpType] = None) -> str:
     from packaging.version import Version
 
     v = Version(version)
-    if bump == BumpType.MAJOR:
+    if bump == BumpType.MAJOR.value:
         v = Version(f"{v.major + 1}.0.0")
-    elif bump == BumpType.MINOR:
+    elif bump == BumpType.MINOR.value:
         v = Version(f"{v.major}.{v.minor + 1}.0")
     else:
         v = Version(f"{v.major}.{v.minor}.{v.micro + 1}")


### PR DESCRIPTION
In Python 3.11, [string enums are no longer literal strings](https://discuss.python.org/t/inconsistent-behavior-with-python-3-11-enum-mixin-class-behavior/24613).

This PR explicitly calls `.value` on all enums.