### PR TITLE
Unlock langchain demos

### DIFF
--- a/arcee/__init__.py
+++ b/arcee/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.1.2"
+__version__ = "0.1.3"
 
 import os
 

--- a/arcee/dalm.py
+++ b/arcee/dalm.py
@@ -8,7 +8,7 @@ from arcee.schemas.routes import Route
 
 
 def check_model_status(name: str) -> Dict[str, str]:
-    route = Route.train_model_status.value.format(id_or_name=name) + "?allow_demo=True"
+    route = Route.train_model_status.value.format(id_or_name=name)
     return make_request("get", route)
 
 

--- a/arcee/schemas/routes.py
+++ b/arcee/schemas/routes.py
@@ -4,7 +4,7 @@ from strenum import StrEnum
 class Route(StrEnum):
     contexts = "contexts"
     train_model = "models/train"
-    train_model_status = "models/status/{id_or_name}"
+    train_model_status = "models/status/{id_or_name}?allow_demo=True"
     train_retriever = "retrievers/train"
     train_retriever_status = "retrievers/status/{id_or_name}"
     identity = "whoami"


### PR DESCRIPTION
Unlocks langchain demos by updating the underlying route it pulls from

https://github.com/langchain-ai/langchain/blob/8329f81072d3b57e6625ff27e429516f4c0634ab/libs/langchain/langchain/utilities/arcee.py#L125C89-L125C89