### PR TITLE
Revert "update build"

### DIFF
--- a/arcee/__init__.py
+++ b/arcee/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.0.2"
+__version__ = "1.0.1"
 
 import os
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,14 +21,11 @@ dependencies = [
     "StrEnum"
 ]
 
-[project.packages]
-include = ["arcee"]
+[project.scripts]
+arcee = "arcee.cli:cli"
 
-[tool.hatch.build.targets.wheel]
-packages = ["arcee"]
-
-[tool.hatch.version]
-path = "arcee/__init__.py"
+[tool.hatch.build.targets.wheel.shared-data]
+"prefix" = "prefix"
 
 [tool.hatch.version]
 path = "arcee/__init__.py"


### PR DESCRIPTION
This reverts commit 7c5d9d6dcb4857e91995e7cf600de40a5c90e3da.

I'm getting this error while trying to `pip install`:

```
$ pip install -e .
Obtaining file:///home/ubuntu/arcee-python
ERROR: Exception:
Traceback (most recent call last):
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/cli/base_command.py", line 180, in exc_logging_wrapper
    status = run_func(*args)
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/cli/req_command.py", line 245, in wrapper
    return func(self, options, args)
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/commands/install.py", line 377, in run
    requirement_set = resolver.resolve(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/resolver.py", line 76, in resolve
    collected = self.factory.collect_root_requirements(root_reqs)
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 513, in collect_root_requirements
    reqs = list(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 474, in _make_requirements_from_install_req
    cand = self._make_candidate_from_link(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/factory.py", line 190, in _make_candidate_from_link
    self._editable_candidate_cache[link] = EditableCandidate(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 318, in __init__
    super().__init__(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 156, in __init__
    self.dist = self._prepare()
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 225, in _prepare
    dist = self._prepare_distribution()
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/resolution/resolvelib/candidates.py", line 328, in _prepare_distribution
    return self._factory.preparer.prepare_editable_requirement(self._ireq)
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 696, in prepare_editable_requirement
    dist = _get_prepared_distribution(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/operations/prepare.py", line 71, in _get_prepared_distribution
    abstract_dist.prepare_distribution_metadata(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/distributions/sdist.py", line 37, in prepare_distribution_metadata
    self.req.load_pyproject_toml()
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/req/req_install.py", line 506, in load_pyproject_toml
    pyproject_toml_data = load_pyproject_toml(
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_internal/pyproject.py", line 64, in load_pyproject_toml
    pp_toml = tomli.loads(f.read())
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_vendor/tomli/_parser.py", line 113, in loads
    pos, header = create_dict_rule(src, pos, out)
  File "/home/ubuntu/miniconda3/envs/arcee-train/lib/python3.10/site-packages/pip/_vendor/tomli/_parser.py", line 290, in create_dict_rule
    raise suffixed_err(src, pos, f"Cannot declare {key} twice")
pip._vendor.tomli.TOMLDecodeError: Cannot declare ('project', 'packages') twice (at line 24, column 18)
```