### PR TITLE
Upload HF dataset in chatml format as qa pairs

### DIFF
--- a/arcee/__init__.py
+++ b/arcee/__init__.py
@@ -3,7 +3,7 @@ __version__ = "1.0.8"
 import os
 
 from arcee import config
-from arcee.api import upload_docs, upload_corpus_folder, upload_qa_pairs, start_alignment, start_pretraining, start_retriever_training, get_retriever_status, start_deployment, stop_deployment, generate, retrieve, delete_corpus, upload_alignment, start_merging
+from arcee.api import upload_docs, upload_corpus_folder, upload_qa_pairs, start_alignment, start_pretraining, start_retriever_training, get_retriever_status, start_deployment, stop_deployment, generate, retrieve, delete_corpus, upload_alignment, start_merging, upload_hugging_face_dataset_qa_pairs
 from arcee.dalm import DALM, DALMFilter
 
 if not config.ARCEE_API_KEY:
@@ -13,4 +13,4 @@ if not config.ARCEE_API_KEY:
         config.ARCEE_API_KEY = input("ARCEE_API_KEY not found in environment. Please input api key: ")
     os.environ["ARCEE_API_KEY"] = config.ARCEE_API_KEY
 
-__all__ = ["upload_docs", "DALM", "DALMFilter", "upload_corpus_folder", "upload_qa_pairs", "start_alignment", "start_pretraining", "start_retriever_training", "get_retriever_status", "start_deployment", "stop_deployment", "generate", "retrieve", "delete_corpus", "upload_alignment", "start_merging"]
+__all__ = ["upload_docs", "DALM", "DALMFilter", "upload_corpus_folder", "upload_qa_pairs", "start_alignment", "start_pretraining", "start_retriever_training", "get_retriever_status", "start_deployment", "stop_deployment", "generate", "retrieve", "delete_corpus", "upload_alignment", "start_merging", "upload_hugging_face_dataset_qa_pairs"]

--- a/arcee/api.py
+++ b/arcee/api.py
@@ -52,57 +52,52 @@ def upload_qa_pairs(qa_set: str, qa_pairs: List[Dict[str, str]]) -> Dict[str, st
     return make_request("post", Route.alignment+"/qaUpload", data)
 
 
-def upload_hugging_face_dataset_qa_pairs(qa_set: str, hf_dataset_id: str, dataset_split: str, csv_format: str) -> Dict[str, str]:
+def upload_hugging_face_dataset_qa_pairs(qa_set: str, hf_dataset_id: str, dataset_split: str, data_format: str) -> None:
     """
-    Upload a list of QA pairs to a specific QA set.
+    Upload a list of QA pairs from a hugging face dataset to a specific QA set.
 
     Args:
         qa_set (str): The name of the QA set to upload to.
-        hf_dataset_id (str): The HF dataset (eg, HuggingFaceH4/ultrachat_200k) that contains QA pairs in either a QA or ChatML format.
-        dataset_split (str): The dataset split, eg, "train", "train_sft", etc..
+        hf_dataset_id (str): The HF dataset id (eg, org/dataset) that contains ChatML format in a 'messages' column.
+        dataset_split (str): The name of the dataset split to use, eg, "train", "train_sft", etc..
+        data_format (str): The format of the data in the dataset.  Only "chatml" is currently supported, and it can only be single turn, not multi-turn.  
 
     Returns:
-        Dict[str, str]: The response from the make_request call.
+        None
     """
 
+    if data_format != "chatml":
+        raise Exception(f"{data_format} not supported yet, only chatml is supported")
 
-    if csv_format == "qa":
-        raise Exception("csv_format 'qa' is not supported yet")
+    qa_pairs = []
 
-    elif csv_format == "chatml":
+    # Load dataset from HF
+    dataset = load_dataset(hf_dataset_id)
+    
+    # Convert the split to pandas
+    df = dataset[dataset_split].to_pandas()
 
-        qa_pairs = []
+    # Loop over all the rows in df and convert the messages into QA pairs
+    for i, row in df.iterrows():
+        try:            
+            qa_pair_tuple = _chat_ml_messages_to_qa_pair(row["messages"])
+            qa_pair = {"question": qa_pair_tuple[0], "answer": qa_pair_tuple[1]}
+            qa_pairs.append(qa_pair)
+        except Exception as e:
+            print(f"Error on row {i}: {e}.  Skipping row")
+            continue
 
-        # Load dataset from HF
-        dataset = load_dataset(hf_dataset_id)
+    batch_size = 200
+
+    print(f"Uploading {len(qa_pairs)} QA pairs in batches of {batch_size}")
+
+    # Upload in chunks of batch_size
+    for i in range(0, len(qa_pairs), batch_size):
+        chunk = qa_pairs[i:i+batch_size]
+        print(f"Uploading {batch_size} QA pairs..")
+        upload_qa_pairs(qa_set, chunk)
         
-        # Convert the split to pandas
-        df = dataset[dataset_split].to_pandas()
-
-        # Loop over all the rows in df and convert the messages into QA pairs
-        for i, row in df.iterrows():
-            try:            
-                qa_pair_tuple = _chat_ml_messages_to_qa_pair(row["messages"])
-                qa_pair = {"question": qa_pair_tuple[0], "answer": qa_pair_tuple[1]}
-                qa_pairs.append(qa_pair)
-            except Exception as e:
-                print(f"Error on row {i}: {e}.  Skipping row")
-                continue
-
-        print(f"Uploading {len(qa_pairs)} QA pairs")
-
-        batch_size = 1000
-
-        # Upload in chunks of batch_size
-        for i in range(0, len(qa_pairs), batch_size):
-            chunk = qa_pairs[i:i+batch_size]
-            print(f"Uploading {batch_size} QA pairs..")
-            upload_qa_pairs(qa_set, chunk)
-            print(f"Uploaded {batch_size} QA pairs..")
-
-    else:
-        raise Exception("csv_format must be either 'qa' or 'chatml'")
-
+    print(f"Finished uploading QA pairs")
 
 
 def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:

--- a/arcee/api_helpers.py
+++ b/arcee/api_helpers.py
@@ -1,0 +1,53 @@
+import numpy as np
+
+def _chat_ml_messages_to_qa_pair(messages: np.ndarray) -> (str, str):
+    """
+    Helper function to convert a ChatML messages field into a QA pair.
+
+    Given a ChatML messages field, like:
+
+    [
+        {
+            "content": "Does this feature apply to all sections of the theme or just specific ones as listed in the text material?",
+            "role": "user"
+        },
+        {
+            "content": "This feature only applies to Collection pages and Featured Collections sections of the section-based themes listed in the text material.",
+            "role": "assistant"
+        },
+        {
+            "content": "Can you guide me through the process of enabling the secondary image hover feature on my Collection pages and Featured Collections sections?",
+            "role": "user"
+        },
+        {
+            "content": "Sure, here are the steps to enable the secondary image hover [snip ..].",
+            "role": "assistant"
+        },
+        etc ..
+    ]
+
+    Extract the _first_ user message and the _first_ assistant message and return them as a QA pair.
+
+    Args:
+        messages (np.ndarray): Array of messages.
+
+    Returns:
+        (str, str): A tuple of a question and an answer.
+
+    """
+
+    # The first role should be a user role
+    if messages[0]["role"] != "user":
+        raise Exception("First message must be a user message")
+
+    # Get the question
+    question = messages[0]["content"]
+
+    # The second message role should be an assistant role
+    if messages[1]["role"] != "assistant":
+        raise Exception("Second message must be an assistant message")
+
+    # Get the answer
+    answer = messages[1]["content"]
+
+    return (question, answer)

--- a/arcee/api_helpers.py
+++ b/arcee/api_helpers.py
@@ -36,6 +36,9 @@ def _chat_ml_messages_to_qa_pair(messages: np.ndarray) -> (str, str):
 
     """
 
+    if len(messages) > 2:
+        raise Exception(f"Only single turn conversations are supported.  Found {len(messages)} messages, which indicates a multi-turn conversation.")
+
     # The first role should be a user role
     if messages[0]["role"] != "user":
         raise Exception("First message must be a user message")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,8 @@ dependencies = [
     "typer",
     "rich",
     "pydantic>=2.4.2,<3.0",
-    "StrEnum"
+    "StrEnum",
+    "datasets"
 ]
 
 [tool.hatch.build.targets.wheel]


### PR DESCRIPTION
This PR adds the ability to upload a hugging face dataset in ChatML format as QA pairs into Arcee.

It only supports single turn rows.  If it is a multiturn row, with more than one user + assistant conversation, it will print a warning and discard the row.

For now it only supports ChatML where the ChatML is in the `messages` column.

## Testing

In a python shell, run this:

```
from arcee import api
api.upload_hugging_face_dataset_qa_pairs("qa_set_name", "org/dataset", "train", "chatml")
```

Output:

```
Uploading 207865 QA pairs
Uploading 1000 QA pairs..
Uploaded 1000 QA pairs..
...
```