### PR TITLE
Add target_compute and capacity_id params to pretraining and alignment

### DIFF
--- a/arcee/api.py
+++ b/arcee/api.py
@@ -185,11 +185,12 @@ def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:
 
 
 def start_pretraining(
-        pretraining_name: str, 
-        corpus: str, 
-        base_model: str, 
-        target_compute: Optional[str] = None,
-        capacity_id: Optional[str] = None) -> Dict[str, str]:
+    pretraining_name: str,
+    corpus: str,
+    base_model: str,
+    target_compute: Optional[str] = None,
+    capacity_id: Optional[str] = None,
+) -> Dict[str, str]:
     """
     Start pretraining a model
 
@@ -201,11 +202,7 @@ def start_pretraining(
         capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
     """
 
-    data = {
-        "pretraining_name": pretraining_name,
-        "corpus_name": corpus, 
-        "base_model": base_model
-    }
+    data = {"pretraining_name": pretraining_name, "corpus_name": corpus, "base_model": base_model}
 
     if target_compute:
         data["target_compute"] = target_compute
@@ -216,10 +213,9 @@ def start_pretraining(
     return make_request("post", Route.pretraining + "/startTraining", data)
 
 
-def mergekit_yaml(merging_name: str,
-                  merging_yaml_path: str,
-                  target_compute: Optional[str] = None,
-                  capacity_id: Optional[str] = None) -> Dict[str, str]:
+def mergekit_yaml(
+    merging_name: str, merging_yaml_path: str, target_compute: Optional[str] = None, capacity_id: Optional[str] = None
+) -> Dict[str, str]:
     """
     Start merging models
 
@@ -239,10 +235,7 @@ def mergekit_yaml(merging_name: str,
     with open(merging_yaml_path, "r") as file:
         merging_yaml = yaml.safe_load(file)
 
-        data = {
-            "merging_name": merging_name,
-            "best_merge_yaml": str(merging_yaml)
-        }
+        data = {"merging_name": merging_name, "best_merge_yaml": str(merging_yaml)}
 
         if target_compute:
             data["target_compute"] = target_compute

--- a/arcee/api.py
+++ b/arcee/api.py
@@ -195,11 +195,15 @@ def start_pretraining(
     Start pretraining a model
 
     Args:
-        pretraining_name (str): The name of the pretraining job
-        corpus (str): The name of the corpus to use
-        base_model (str): The name of the base model to use
-        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
-        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
+        pretraining_name (str): The name of the pretraining job.
+        corpus (str): The name of the corpus to use.
+        base_model (str): The name of the base model to use.
+        target_compute (Optional[str]): The name of the compute to use,
+            e.g., "g5.2xlarge" or "capacity". If omitted, the default
+            compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block ID
+            to use. If omitted, an instance will be launched to perform
+            training.
     """
 
     data = {"pretraining_name": pretraining_name, "corpus_name": corpus, "base_model": base_model}
@@ -220,10 +224,15 @@ def mergekit_yaml(
     Start merging models
 
     Args:
-        merging_name (str): The name of the merging job
-        merging_yaml (str): The yaml file containing the merging instructions - https://github.com/arcee-ai/mergekit/tree/main/examples
-        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
-        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
+        merging_name (str): The name of the merging job.
+        merging_yaml (str): The yaml file containing the merging
+            instructions - https://github.com/arcee-ai/mergekit/tree/main/examples.
+        target_compute (Optional[str]): The name of the compute to use,
+            e.g., "g5.2xlarge" or "capacity". If omitted, the default
+            compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block ID
+            to use. If omitted, an instance will be launched to perform
+            training.
     """
 
     if not merging_yaml_path.endswith(".yaml"):
@@ -336,9 +345,6 @@ def start_alignment(
 ) -> Dict[str, str]:
     """
     Start the alignment of a model.
-    This function submits a request to
-    begin the alignment process using
-    the specified models.
 
     Args:
         alignment_name (str): The name of the alignment job.
@@ -346,8 +352,10 @@ def start_alignment(
         pretrained_model (Optional[str]): The name of the pretrained model to use, if any.
         merging_model (Optional[str]): The name of the merging model to use, if any.
         alignment_model (Optional[str]): The name of the final alignment model to use, if any.
-        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
-        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
+        target_compute (Optional[str]): The name of the compute to use, e.g., "g5.2xlarge" or
+            "capacity". If omitted, the default compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block ID to use. If omitted, an
+            instance will be launched to perform training.
     """
 
     data = {

--- a/arcee/api.py
+++ b/arcee/api.py
@@ -184,7 +184,12 @@ def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:
     return make_request("post", Route.contexts, data)
 
 
-def start_pretraining(pretraining_name: str, corpus: str, base_model: str, target_compute: Optional[str] = None) -> Dict[str, str]:
+def start_pretraining(
+        pretraining_name: str, 
+        corpus: str, 
+        base_model: str, 
+        target_compute: Optional[str] = None,
+        capacity_id: Optional[str] = None) -> Dict[str, str]:
     """
     Start pretraining a model
 
@@ -193,6 +198,7 @@ def start_pretraining(pretraining_name: str, corpus: str, base_model: str, targe
         corpus (str): The name of the corpus to use
         base_model (str): The name of the base model to use
         target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
     """
 
     data = {
@@ -204,10 +210,16 @@ def start_pretraining(pretraining_name: str, corpus: str, base_model: str, targe
     if target_compute:
         data["target_compute"] = target_compute
 
+    if capacity_id:
+        data["capacity_id"] = capacity_id
+
     return make_request("post", Route.pretraining + "/startTraining", data)
 
 
-def mergekit_yaml(merging_name: str, merging_yaml_path: str, target_compute: Optional[str] = None) -> Dict[str, str]:
+def mergekit_yaml(merging_name: str,
+                  merging_yaml_path: str,
+                  target_compute: Optional[str] = None,
+                  capacity_id: Optional[str] = None) -> Dict[str, str]:
     """
     Start merging models
 
@@ -215,6 +227,7 @@ def mergekit_yaml(merging_name: str, merging_yaml_path: str, target_compute: Opt
         merging_name (str): The name of the merging job
         merging_yaml (str): The yaml file containing the merging instructions - https://github.com/arcee-ai/mergekit/tree/main/examples
         target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
     """
 
     if not merging_yaml_path.endswith(".yaml"):
@@ -226,7 +239,16 @@ def mergekit_yaml(merging_name: str, merging_yaml_path: str, target_compute: Opt
     with open(merging_yaml_path, "r") as file:
         merging_yaml = yaml.safe_load(file)
 
-        data = {"merging_name": merging_name, "best_merge_yaml": str(merging_yaml), "target_compute": target_compute}
+        data = {
+            "merging_name": merging_name,
+            "best_merge_yaml": str(merging_yaml)
+        }
+
+        if target_compute:
+            data["target_compute"] = target_compute
+
+        if capacity_id:
+            data["capacity_id"] = capacity_id
 
         return make_request("post", Route.merging + "/start", data)
 
@@ -317,6 +339,7 @@ def start_alignment(
     merging_model: Optional[str] = None,
     alignment_model: Optional[str] = None,
     target_compute: Optional[str] = None,
+    capacity_id: Optional[str] = None,
 ) -> Dict[str, str]:
     """
     Start the alignment of a model.
@@ -331,6 +354,7 @@ def start_alignment(
         merging_model (Optional[str]): The name of the merging model to use, if any.
         alignment_model (Optional[str]): The name of the final alignment model to use, if any.
         target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
+        capacity_id (Optional[str]): The name of the capacity block id to use.  If omitted, an instance will be launched to perform training.
     """
 
     data = {
@@ -343,6 +367,9 @@ def start_alignment(
 
     if target_compute:
         data["target_compute"] = target_compute
+
+    if capacity_id:
+        data["capacity_id"] = capacity_id
 
     # Assuming make_request is a function that handles the request, it's called here
     return make_request("post", Route.alignment + "/startAlignment", data)

--- a/arcee/api.py
+++ b/arcee/api.py
@@ -184,7 +184,7 @@ def upload_docs(context: str, docs: List[Dict[str, str]]) -> Dict[str, str]:
     return make_request("post", Route.contexts, data)
 
 
-def start_pretraining(pretraining_name: str, corpus: str, base_model: str) -> Dict[str, str]:
+def start_pretraining(pretraining_name: str, corpus: str, base_model: str, target_compute: Optional[str] = None) -> Dict[str, str]:
     """
     Start pretraining a model
 
@@ -192,9 +192,17 @@ def start_pretraining(pretraining_name: str, corpus: str, base_model: str) -> Di
         pretraining_name (str): The name of the pretraining job
         corpus (str): The name of the corpus to use
         base_model (str): The name of the base model to use
+        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
     """
 
-    data = {"pretraining_name": pretraining_name, "corpus_name": corpus, "base_model": base_model}
+    data = {
+        "pretraining_name": pretraining_name,
+        "corpus_name": corpus, 
+        "base_model": base_model
+    }
+
+    if target_compute:
+        data["target_compute"] = target_compute
 
     return make_request("post", Route.pretraining + "/startTraining", data)
 
@@ -206,6 +214,7 @@ def mergekit_yaml(merging_name: str, merging_yaml_path: str, target_compute: Opt
     Args:
         merging_name (str): The name of the merging job
         merging_yaml (str): The yaml file containing the merging instructions - https://github.com/arcee-ai/mergekit/tree/main/examples
+        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
     """
 
     if not merging_yaml_path.endswith(".yaml"):
@@ -307,6 +316,7 @@ def start_alignment(
     pretrained_model: Optional[str] = None,
     merging_model: Optional[str] = None,
     alignment_model: Optional[str] = None,
+    target_compute: Optional[str] = None,
 ) -> Dict[str, str]:
     """
     Start the alignment of a model.
@@ -320,6 +330,7 @@ def start_alignment(
         pretrained_model (Optional[str]): The name of the pretrained model to use, if any.
         merging_model (Optional[str]): The name of the merging model to use, if any.
         alignment_model (Optional[str]): The name of the final alignment model to use, if any.
+        target_compute (Optional[str]): The name of the compute to use, eg: "g5.2xlarge" or "capacity".  If omitted, the default compute will be used.
     """
 
     data = {
@@ -329,6 +340,9 @@ def start_alignment(
         "merging_model": merging_model,
         "alignment_model": alignment_model,
     }
+
+    if target_compute:
+        data["target_compute"] = target_compute
 
     # Assuming make_request is a function that handles the request, it's called here
     return make_request("post", Route.alignment + "/startAlignment", data)


### PR DESCRIPTION
Currently the arcee-python client doesn't support passing in a target_compute or a capacity_id parameter.  This PR adds that ability.

I manually tested it via the cli