### PR TITLE
Create parent directories for the configuration file if they're missing

### DIFF
--- a/arcee/config.py
+++ b/arcee/config.py
@@ -39,6 +39,7 @@ def write_configuration_value(key: str, value: str) -> None:
             except json.JSONDecodeError:
                 pass
     else:
+        conf_path.parent.mkdir(parents=True, exist_ok=True)
         conf_path.touch()
 
     config[key] = value


### PR DESCRIPTION

This is a fix for #78. I only tested it on MacOS, but it should be platform-independent.

