### PR TITLE
Add Evaluation Support to Arcee Python SDK

### DIFF
--- a/arcee/__init__.py
+++ b/arcee/__init__.py
@@ -9,6 +9,7 @@ from arcee.api import (
     delete_corpus,
     deployment_status,
     generate,
+    get_evaluation_status,
     get_retriever_status,
     list_pretrainings,
     mergekit_evolve,
@@ -61,4 +62,5 @@ __all__ = [
     "merging_status",
     "alignment_status",
     "start_evaluation",
+    "get_evaluation_status",
 ]

--- a/arcee/__init__.py
+++ b/arcee/__init__.py
@@ -17,6 +17,7 @@ from arcee.api import (
     retrieve,
     start_alignment,
     start_deployment,
+    start_evaluation,
     start_pretraining,
     start_retriever_training,
     stop_deployment,
@@ -59,4 +60,5 @@ __all__ = [
     "deployment_status",
     "merging_status",
     "alignment_status",
+    "start_evaluation",
 ]

--- a/arcee/api.py
+++ b/arcee/api.py
@@ -551,9 +551,20 @@ def start_evaluation(
     """
     Start an evaluation job.
 
+    To run lm-eval-harness benchmarks, the input should be in a format similar to:
+    {
+        "evaluations_name": "my_lm_eval_harness_test",
+        "eval_type": "lm-eval-harness",
+        "model_type": "arcee",  # or "hf" depending on your model
+        "model_args": "pretrained=my_model_name,use_accelerate=True",  # Adjust based on https://github.com/EleutherAI/lm-evaluation-harness
+        "tasks_list": ["hellaswag", "mmlu_stem"],  # List of tasks to evaluate
+    }
+
     LLM as a judge model config should be in a format similar to:
     deployment_model = {
-        "model_name": "arcee-model-name"
+        "model_name": "arcee_model_name",
+        "base_url": "https://app.arcee.ai/api/v2",
+        "api_key": f"{os.environ['ARCEE_API_KEY']}"
     }
     reference_model" = {
         "model_name": "claude-3-5-sonnet-20240620",
@@ -562,7 +573,7 @@ def start_evaluation(
     }
     judge_model = {
         "model_name": "gpt-4o",
-        "base_url": "https://api.openai.com/v1/",
+        "base_url": "https://api.openai.com/v1",
         "api_key": openai_api_key,
         "custom_prompt": "Evaluate which response better adheres to factual accuracy, clarity, and relevance."
     }
@@ -583,6 +594,7 @@ def start_evaluation(
     """
 
     data = {
+        "action": "start",
         "evaluations_name": evaluations_name,
         "model_type": model_type,
         "model_args": model_args,
@@ -600,4 +612,4 @@ def start_evaluation(
     # Remove any keys with None values
     data = {k: v for k, v in data.items() if v is not None}
 
-    return make_request("post", Route.evaluation + "/evaluation/start", data)
+    return make_request("post", Route.evaluation + "/start", data)

--- a/arcee/schemas/routes.py
+++ b/arcee/schemas/routes.py
@@ -15,3 +15,4 @@ class Route(StrEnum):
     deployment = "deployment"
     merging = "merging"
     retriever = "models"
+    evaluation = "evaluation"


### PR DESCRIPTION
This PR introduces support for evaluations in the Arcee Python SDK.
Added `start_evaluation` function to `arcee/api.py`:
   - Allows users to initiate various types of evaluation jobs, including LLM-as-a-judge and lm-eval-harness benchmarks.

## Usage Example for testing

```
import os
os.environ['ARCEE_API_URL'] = 'https://arcee-dev.dev.arcee.ai/api'
os.environ['ARCEE_ORG'] = 'rivinduorg'
os.environ['ARCEE_API_KEY'] = ''

openai_api_key = ''

import arcee
evaluation_params = {'evaluations_name': 'evals_test_oct7',
 'eval_type': 'llm_as_a_judge',
 'qa_set_name': 'mmlu_20q',
 'judge_model': {'model_name': 'gpt-4o',
  'custom_prompt': 'Evaluate which response better adheres to factual accuracy, clarity, and relevance.',
  'base_url': 'https://api.openai.com/v1',
  'api_key': openai_api_key},
 'deployment_model': {'model_name': 'gpt-4o-mini',
  'base_url': 'https://api.openai.com/v1',
  'api_key': openai_api_key},
 'reference_model': {'model_name': 'gpt-3.5-turbo-0125',
  'base_url': 'https://api.openai.com/v1',
  'api_key': openai_api_key}}

result = arcee.start_evaluation(**evaluation_params)
eval_status = arcee.get_evaluation_status(result['evaluations_id'])
```

<img width="1083" alt="image" src="https://github.com/user-attachments/assets/3a4ca1f4-10ae-4b18-94f2-d32f0fd4ba3f">
